### PR TITLE
fix a bug in stop_all. Kill cita-forever first, and kill all other mi…

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -139,14 +139,14 @@ impl Processes {
 
     // stop all processes
     pub fn stop_all(mut self) {
+        // stop parent process
+        self.stop();
+
         // stop all child process
-        for (_, child_process) in self.children.clone() {
+        for (_, child_process) in self.children {
             let mut process = child_process.lock();
             process.stop();
         }
-
-        // stop parent process
-        self.stop();
     }
 
     // all child processes logrotate


### PR DESCRIPTION
fix a bug in stop_all. Kill cita-forever first, and kill all other micro service processes.

Signed-off-by: Mike Tang <miketang@cryptape.com>