### PR TITLE
Hard code release version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "cita-forever"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -112,7 +112,7 @@ dependencies = [
 [[package]]
 name = "cita-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#788444602d6181741281c06c2684d3d60374a350"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
 dependencies = [
  "ethereum-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain_hasher 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "panic_hook"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#788444602d6181741281c06c2684d3d60374a350"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.2.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#788444602d6181741281c06c2684d3d60374a350"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
 dependencies = [
  "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "snappy"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#788444602d6181741281c06c2684d3d60374a350"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -896,7 +896,7 @@ dependencies = [
 [[package]]
 name = "util"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#788444602d6181741281c06c2684d3d60374a350"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cita-forever"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,9 @@ use std::env;
 
 use util::build_info::gen_build_info;
 
+const VERSION: &str = "1.0.0";
+
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    gen_build_info(out_dir.as_ref(), "build_info.rs");
+    gen_build_info(out_dir.as_ref(), "build_info.rs", VERSION.to_owned());
 }


### PR DESCRIPTION
Hard code release version.

**Note** : This PR will be finished after https://github.com/cryptape/cita-common/pull/299 .

After this PR merged, the micro-service version will be:
```
${SERVICE_NAME} ${HARD_CODE_VERSION}-${COMMIT_ID}
```
e.g.
![Screenshot from 2019-09-10 18-11-46](https://user-images.githubusercontent.com/38514341/64605334-7f241f00-d3f6-11e9-8173-f63fe4b5e81a.png)
